### PR TITLE
Bugfix/bmi duration almost infinite

### DIFF
--- a/src/Raven_BMI.cpp
+++ b/src/Raven_BMI.cpp
@@ -297,6 +297,9 @@ void CRavenBMI::Initialize(std::string config_file)
   pModel->SummarizeToScreen           (Options);
   pModel->GetEnsemble()->Initialize   (pModel,Options);
 
+  // something in the previous steps might have changed the duration, so we may need to set it again
+  Options.duration = ALMOST_INF;  // "infinity": will run as long as "Update()" is called
+
   CheckForErrorWarnings(false, pModel);
 
   // all the output variables must be checked
@@ -331,7 +334,6 @@ void CRavenBMI::Initialize(std::string config_file)
   pModel->UpdateHRUForcingFunctions  (Options,tt);
   pModel->UpdateDiagnostics          (Options,tt);
   pModel->WriteMinorOutput           (Options,tt);
-
 }
 
 //////////////////////////////////////////////////////////////////

--- a/src/Raven_BMI.cpp
+++ b/src/Raven_BMI.cpp
@@ -282,8 +282,7 @@ void CRavenBMI::Initialize(std::string config_file)
   WARNINGS.close();
 
   Options.in_bmi_mode  = true;  // flag needed to ignore some arguments of the .rvi file
-  Options.rvt_filename = "";   // just a dummy filename to avoid errors
-  Options.duration     = ALMOST_INF;  // "infinity": will run as long as "Update()" is called
+  Options.rvt_filename = "";    // just a dummy filename to avoid errors
 
   //Read input files, create model, set model options
   if (!ParseInputFiles(pModel, Options)){
@@ -297,8 +296,10 @@ void CRavenBMI::Initialize(std::string config_file)
   pModel->SummarizeToScreen           (Options);
   pModel->GetEnsemble()->Initialize   (pModel,Options);
 
-  // something in the previous steps might have changed the duration, so we may need to set it again
-  Options.duration = ALMOST_INF;  // "infinity": will run as long as "Update()" is called
+  // pModel->Initialize() sets the duration to 365 (days) by default, but in BMI mode the duration
+  //  of the simulation is governed by the framwork consuming the BMI interface, so we set the
+  //  duration to ALMOST_INF(inite) to avoid the model stopping by itself
+  Options.duration = ALMOST_INF;
 
   CheckForErrorWarnings(false, pModel);
 


### PR DESCRIPTION
As ```pModel->Initialize()``` changes the value of ```Options.duration``` to ```365``` (the default), the setting of ```Options.duration``` to "almost infinite" needs to take place **after** ```pModel->Initialize()``` to persist.